### PR TITLE
Added steering to NPCs

### DIFF
--- a/NPC.tscn
+++ b/NPC.tscn
@@ -38,7 +38,9 @@ tracks/1/keys = {
 "values": [ false, true ]
 }
 
-[node name="NPC" type="KinematicBody2D"]
+[node name="NPC" type="KinematicBody2D" groups=[
+"npc",
+]]
 script = ExtResource( 1 )
 
 [node name="TempSprite" type="Line2D" parent="."]


### PR DESCRIPTION
NPCs use steering for wandering and for mob following, just set a different target.
When mob moves, it emits a signal to all members to be followed. (also on stop)
I need to improve NPC stop follow to allow better group and wander for ones in outer area.

I checked the code and it works. It also solves the problem of "in_mob" in exported vars that caused all NPCs to follow anyway the mob.