### PR TITLE
Added timer to decrease commitment

### DIFF
--- a/Ability.gd
+++ b/Ability.gd
@@ -59,6 +59,8 @@ func remove_ability():
 
 
 func set_button(n):
+	if n >= button_names.size() or n >= buttons.size()  :
+		return
 	$Hotkey.text = button_names[n] # button_names[n] TODO
 	button_code = buttons[n] # buttons[n] TODO
 

--- a/NPC.gd
+++ b/NPC.gd
@@ -203,8 +203,8 @@ func get_mob():
 
 
 func chant(message):
-	if !in_mob:
-		return
+#	if !in_mob:
+#		return
 	var nearby_bodies = $Attack.get_overlapping_bodies()
 	for body in nearby_bodies:
 		if body.is_in_group("npc"):

--- a/NPC.gd
+++ b/NPC.gd
@@ -72,6 +72,10 @@ var mob_pathfinding_queue = []
 
 var chant_relocate_cooldown = 0.0
 
+#used to periodically check commitment and decrease if too distant
+export (float) var MOB_MAX_DISTANCE = 120.0 
+export (int) var COMMITMENT_LOOSE = -2
+#Commitment timer is set in inspector and triggers every 15 seconds
 
 func _ready():
 	# Random number generation will always result in the same values each
@@ -315,7 +319,6 @@ func commitment_change(damage):
 	commitment_change_instance.position = position
 	add_child(commitment_change_instance)
 
-
 func set_direction(new_direction):
 	if new_direction == "up" or new_direction == "down" or new_direction == direction:
 		return
@@ -326,3 +329,10 @@ func set_direction(new_direction):
 # NOT USED YET
 func buff(buff_range):
 	pass
+
+
+func _on_CommitmentTimer_timeout() -> void:
+	if not in_mob:
+		return
+	if global_position.distance_to(get_mob().global_position) > MOB_MAX_DISTANCE:
+		commitment_change(COMMITMENT_LOOSE)

--- a/NPC.tscn
+++ b/NPC.tscn
@@ -140,3 +140,8 @@ frame = 2
 [node name="SpriteAnimationPlayer" type="AnimationPlayer" parent="."]
 anims/idle = SubResource( 4 )
 anims/run = SubResource( 5 )
+
+[node name="CommitmentTimer" type="Timer" parent="."]
+wait_time = 15.0
+autostart = true
+[connection signal="timeout" from="CommitmentTimer" to="." method="_on_CommitmentTimer_timeout"]


### PR DESCRIPTION
Added a timer connected using scene interface that decreases commitment if too distant from Mob. Check every 15 seconds. Distance and decrease may be set in inspector. Fixed error in ability that caused a crash sometimes.

_I noticed now that this was in the consider column in Trello.
I wanted to add this as without a form of entropy, I feel like we would loose the "keeping alive the mob aspect". We can disable or edit it anyway._